### PR TITLE
Made /health open for monitoring

### DIFF
--- a/middleware/app/api/routes/health.py
+++ b/middleware/app/api/routes/health.py
@@ -13,9 +13,7 @@ log = logger.get_logger()
 
 
 @router.get("/")
-def health_check(
-    x_api_key: Optional[str] = Header(None),
-):
+def health_check():
     """
     Perform checks to verify system health.
     For instance, check database connection, external services, etc.
@@ -28,9 +26,6 @@ def health_check(
     """
     FUNCTION_NAME = "health_check()"
     log.info("Entering {}".format(FUNCTION_NAME))
-
-    if x_api_key != os.getenv("AWS_API_KEY"):
-        preprocess_external_call(x_api_key)
 
     response = health_service.health_check()
 

--- a/middleware/template.yaml
+++ b/middleware/template.yaml
@@ -102,8 +102,6 @@ Resources:
               Ref: ByteShareAPIGW
             Path: /health
             Method: any
-            Auth:
-              ApiKeyRequired: true
         UploadApi:
           Type: Api
           Properties:


### PR DESCRIPTION
## What does this PR do?

Make /health open to access

## Issue

Fixes #259 

## What changed?

- Removed API key required for health endpoint
- Removed auth check

## Why these changes?

- To make it open to enable monitoring

## Is it tested?

Yes, locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/innovencelabs/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.
