### PR TITLE
Increase max workers in upload and download

### DIFF
--- a/middleware/app/api/services/download.py
+++ b/middleware/app/api/services/download.py
@@ -69,7 +69,7 @@ def get_file_url_return_name_link(token_data, upload_id: str):
 
     file_names = list(upload_metadata["storage_file_metadata"].keys())
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=25) as executor:
         future_to_file_name = {
             executor.submit(_generate_download_url, upload_id, file_name): file_name
             for file_name in file_names

--- a/middleware/app/api/services/upload.py
+++ b/middleware/app/api/services/upload.py
@@ -175,7 +175,7 @@ def verify_upload_return_done(token_data, body: VerifyUpload, upload_id: str):
     storage_file_metadata = upload_metadata["storage_file_metadata"]
     file_names = body.file_names
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=25) as executor:
         future_to_file_name = {
             executor.submit(_verify_file, upload_id, file_name): file_name
             for file_name in file_names


### PR DESCRIPTION
## What does this PR do?

Increase max workers for finalise upload and download

## What changed?

- Changed max worker from 10 to 25

## Why these changes?

- To improve performance

## Is it tested?

Yes, on deployed version

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/innovencelabs/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.
